### PR TITLE
T-TESTS-OVERLAP: Unit tests for detect_file_overlaps and detect_orphan_deps

### DIFF
--- a/tests/test_critic_overlaps.py
+++ b/tests/test_critic_overlaps.py
@@ -1,0 +1,71 @@
+"""Unit tests for detect_file_overlaps and detect_orphan_deps in lib/critic.py."""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Ensure repo root is importable when tests are run from anywhere.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lib.critic import Flag, detect_file_overlaps, detect_orphan_deps
+
+
+# ---------------------------------------------------------------------------
+# detect_file_overlaps
+# ---------------------------------------------------------------------------
+
+def test_no_overlap_returns_empty_list():
+    tasks = [
+        {"id": "T-001", "deps": [], "files_touched": ["lib/a.py"]},
+        {"id": "T-002", "deps": [], "files_touched": ["lib/b.py"]},
+    ]
+    assert detect_file_overlaps(tasks) == []
+
+
+def test_siblings_touching_same_file_flags_overlap():
+    tasks = [
+        {"id": "T-001", "deps": [], "files_touched": ["lib/shared.py"]},
+        {"id": "T-002", "deps": [], "files_touched": ["lib/shared.py"]},
+    ]
+    flags = detect_file_overlaps(tasks)
+    assert len(flags) == 1
+    flag = flags[0]
+    assert isinstance(flag, Flag)
+    assert flag.kind == "file_overlap"
+    assert flag.severity == "warning"
+    assert set(flag.task_ids) == {"T-001", "T-002"}
+
+
+def test_dependent_tasks_touching_same_file_no_flag():
+    tasks = [
+        {"id": "T-001", "deps": [], "files_touched": ["lib/shared.py"]},
+        {"id": "T-002", "deps": ["T-001"], "files_touched": ["lib/shared.py"]},
+    ]
+    assert detect_file_overlaps(tasks) == []
+
+
+# ---------------------------------------------------------------------------
+# detect_orphan_deps
+# ---------------------------------------------------------------------------
+
+def test_orphan_dep_flags_missing_reference():
+    tasks = [
+        {"id": "T-001", "deps": ["T-999"], "files_touched": []},
+    ]
+    flags = detect_orphan_deps(tasks)
+    assert len(flags) == 1
+    flag = flags[0]
+    assert isinstance(flag, Flag)
+    assert flag.kind == "orphan_dep"
+    assert flag.severity == "critical"
+    assert flag.task_ids == ["T-001"]
+
+
+def test_valid_dep_produces_no_flag():
+    tasks = [
+        {"id": "T-001", "deps": [], "files_touched": []},
+        {"id": "T-002", "deps": ["T-001"], "files_touched": []},
+    ]
+    assert detect_orphan_deps(tasks) == []


### PR DESCRIPTION
Add tests/test_critic_overlaps.py with pytest test cases for two functions from lib/critic.py: detect_file_overlaps and detect_orphan_deps. Both functions accept list[dict] — each dict has keys: id (str), deps (list[str]), files_touched (list[str]). They return list[Flag]; import Flag from lib.critic to assert on return values. Cover: (a) no overlap returns empty list, (b) two sibling tasks touching the same file with no dep relationship produces one Flag with kind='file_overlap', (c) two tasks touching the same file where one depends on the other produces no flag, (d) a task whose deps list references a nonexistent id produces a Flag with kind='orphan_dep', (e) a valid dep id produces no flag. Assert on Flag attributes (.kind, .severity, .task_ids). Use plain dicts for all task inputs. Do NOT modify lib/critic.py or any other file outside tests/.

---
<!-- legion-task-id: T-TESTS-OVERLAP -->
Spawned by HolyClaude Legion. Worker container: `ta-01KPKQMEB8XVFVWN30JHBJFWFW`.
