### PR TITLE
T-CI: Add GitHub Actions workflow to run pytest on push and PR

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install pytest==9.0.2
+      - run: pytest tests/ -v


### PR DESCRIPTION
Create a minimal CI workflow at .github/workflows/tests.yml. Requirements: (1) name the workflow 'tests'; (2) trigger on push to main AND on pull_request (any branch); (3) single job 'pytest' running on ubuntu-latest; (4) steps in order: actions/checkout@v4, actions/setup-python@v5 with python-version '3.11', then `pip install pytest==9.0.2` (JUST pytest — do NOT use `pip install -e .` because pyproject.toml has NO [project] section, editable install will fail; the existing `pythonpath = ["."]` pytest config makes imports work), then `pytest tests/ -v`. Do not add caching, matrix builds, coverage, or any other jobs — keep it under 30 lines. Do not modify any file outside .github/.

---
<!-- legion-task-id: T-CI -->
Spawned by HolyClaude Legion. Worker container: `ta-01KPKS06EX6N9007D59XVSXS2Q`.
